### PR TITLE
CircleCI: correct pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ workflows:
           context: logdna-default
           orb-name: logdna/logdna
           alpha-version-ref: dev:${CIRCLE_BRANCH}
+          attach-workspace: true
           requires:
             - orb-tools/pack
 
@@ -49,7 +50,8 @@ workflows:
 
       - orb-tools/publish:
           context: logdna-default
-          filters: *tags_only_filter
           orb-ref: logdna/logdna:${CIRCLE_TAG}
+          attach-workspace: true
+          filters: *tags_only_filter
           requires:
             - orb-tools/pack


### PR DESCRIPTION
When calling orb-tools/publish apparently the workspace is not
attached by default, we need to do this as the packed orb YAML
is stored inside it. This is a strange default as for the
orb-tools/publish-dev command this is defaulted to true.

Also correct the name and the tag we wish to attach to the
released orb.