### PR TITLE
Correct orb reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ workflows:
 
       - orb-tools/publish:
           context: logdna-default
-          orb-ref: logdna/logdna:${CIRCLE_TAG}
+          orb-ref: logdna/logdna@${CIRCLE_TAG}
           attach-workspace: true
           filters: *tags_only_filter
           requires:


### PR DESCRIPTION
Apparently the old syntax was wrong:

```
Error: Invalid orb reference 'logdna/logdna:1.0.0': Expected a
namespace, orb and version in the format 'namespace/orb@version'
```

So lets do in a way to make CircleCI happy.